### PR TITLE
make it easier to package

### DIFF
--- a/kp2bw/convert.py
+++ b/kp2bw/convert.py
@@ -4,7 +4,7 @@ import logging
 from enum import Enum
 from pykeepass import PyKeePass
 
-from bitwardenclient import BitwardenClient
+from .bitwardenclient import BitwardenClient
 
 KP_REF_IDENTIFIER = "{REF:"
 MAX_BW_ITEM_LENGTH = 10 * 1000

--- a/kp2bw/kp2bw.py
+++ b/kp2bw/kp2bw.py
@@ -3,7 +3,7 @@ import getpass
 import logging
 import sys
 
-from convert import Converter
+from .convert import Converter
 
 
 class MyArgParser(argparse.ArgumentParser):
@@ -33,8 +33,7 @@ def _read_password(arg, prompt):
 
     return arg
 
-
-if __name__ == "__main__":
+def main():
     print("⁻" * 58)
     print("--[kp2bw - KeePass 2.x to Bitwarden converter by @jampe]--")
     print("-" * 58)
@@ -77,3 +76,6 @@ if __name__ == "__main__":
 
     print(" ")
     print("All done.")
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pykeepass==4.0.0
+pykeepass>=4.0.0,<5.0.0

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
+from setuptools import setup,find_packages
 
 with open('README.md') as readme_file:
     readme = readme_file.read()
@@ -20,10 +17,12 @@ setup(
     author="Daniel Jampen",
     author_email='daniel@jampen.net',
     url='https://github.zhaw.ch/jampe/kp2bw',
-    packages=[
-        'kp2bw',
-    ],
-    package_dir={'kp2bw': '.'},
+    packages=find_packages(),
+    entry_points={
+        'console_scripts': [
+            'kp2bw = kp2bw.kp2bw:main',
+        ]
+    },
     include_package_data=True,
     install_requires=requirements,
     zip_safe=False,


### PR DESCRIPTION
This PR could make packaging `kp2bw` just works.

As an example, I packaged `kp2bw` with [nix](https://nixos.org/). I can now run `kp2bw` with `nix` by `nix run github:contrun/kp2bw/flake --`. This just works. The code is at [the flake branch](https://github.com/contrun/kp2bw/tree/flake). I am willing create a separate PR for nix flake support, but I am aware of `nix` is not so pervasive.