### PR TITLE
Fixed typo when calling "mkdir" from "os" library

### DIFF
--- a/kp2bw/bitwardenclient.py
+++ b/kp2bw/bitwardenclient.py
@@ -37,7 +37,7 @@ class BitwardenClient():
 
     def _create_temporary_attachment_folder(self):
         if not os.path.isdir(self.TEMPORARY_ATTACHMENT_FOLDER):
-            os.os.mkdir(self.TEMPORARY_ATTACHMENT_FOLDER)
+            os.mkdir(self.TEMPORARY_ATTACHMENT_FOLDER)
 
     def _remove_temporary_attachment_folder(self):
         if os.path.isdir(self.TEMPORARY_ATTACHMENT_FOLDER):


### PR DESCRIPTION
Typo when calling "mkdir" method from "os" library. "os." written twice.

Issue is preventing kp2bw to create the temporary folder needed for attachements. 