### PR TITLE
Added Org and OrgCollectionSupport and NamePrefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 kp2bw/__pycache__/
+.env/
+build/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ optional arguments:
   -kppw KP_PW       KeePass db password
   -kpkf KP_KEYFILE  KeePass db key file
   -bwpw BW_PW       Bitwarden Password
+  -bworg BW_OrgId   Id of Organization to Upload Into
+  -bwcoll BW_CollId Id of Org-Collection, or 'auto' to use name from toplevel-folders
+  -path2name        Prepend folderpath of entries to each name
+  -path2nameskip PATH2NAMESKIP
+                    Skip first X folders for path2name (default: 1)
   -y                Skips the confirm bw installation question
   -v                Verbose output
 ```

--- a/kp2bw/bitwardenclient.py
+++ b/kp2bw/bitwardenclient.py
@@ -11,11 +11,14 @@ from subprocess import STDOUT, CalledProcessError, check_output
 class BitwardenClient():
     TEMPORARY_ATTACHMENT_FOLDER = "attachment-temp"
 
-    def __init__(self, password):
+    def __init__(self, password, orgId):
         # check for bw cli installation
         if not "bitwarden" in self._exec("bw"):
             raise Exception("Bitwarden Cli not installed! See https://help.bitwarden.com/article/cli/#download--install for help")
         
+        # save org
+        self._orgId = orgId
+
         # login
         self._key = self._exec(f"bw unlock {password} --raw")
         if "error" in self._key:
@@ -30,7 +33,13 @@ class BitwardenClient():
 
         # get existing entries
         self._folder_entries = self._get_existing_folder_entries()
-    
+
+        # get existing collections
+        if orgId:
+            self._colls = {coll["name"]: coll["id"] for coll in json.loads(self._exec_with_session(f"bw list org-collections --organizationid {orgId}"))}
+        else:
+            self._colls = None
+
     def __del__(self):
         # cleanup temp directory
         self._remove_temporary_attachment_folder()
@@ -140,3 +149,35 @@ class BitwardenClient():
             os.remove(path_to_file_on_disk)
         
         return output
+
+    def create_org_get_collection(self, collectionname):
+
+        if not collectionname: return None
+
+        # check for existing
+        if self._colls.get(collectionname):
+            return self._colls.get(collectionname)
+
+        # get template
+        entry = json.loads(self._exec_with_session(f"bw get template org-collection"))
+
+        # set org and Name
+        entry['name'] = collectionname
+        entry['organizationId'] = self._orgId
+
+
+        json_str = json.dumps(entry)
+
+        # convert string to base64
+        json_b64 = base64.b64encode(json_str.encode("UTF-8")).decode("UTF-8")
+
+        output = self._exec_with_session(f'{self._get_platform_dependent_echo_str(json_b64)} | bw create  org-collection --organizationid {self._orgId}')
+        if (not output): return None
+        data = json.loads(output)
+        if (not data["id"]): return None
+        newCollId = data["id"]
+
+        #store in cache
+        self._colls[collectionname] = newCollId
+
+        return newCollId

--- a/kp2bw/cli.py
+++ b/kp2bw/cli.py
@@ -19,6 +19,12 @@ def _argparser():
     parser.add_argument('-kppw', dest='kp_pw', help='KeePass db password', default=None)
     parser.add_argument('-kpkf', dest='kp_keyfile', help='KeePass db key file', default=None)
     parser.add_argument('-bwpw', dest='bw_pw', help='Bitwarden password', default=None)
+    parser.add_argument('-bworg', dest='bw_org', help='Bitwarden Organization Id', default=None)
+    parser.add_argument('-bwcoll', dest='bw_coll', help='Id of Org-Collection, or \'auto\' to use name from toplevel-folders', default=None)
+    parser.add_argument('-path2name', dest='path2name', help='Prepend folderpath of entries to each name',
+                        action="store_const", const=True, default=True),
+    parser.add_argument('-path2nameskip', dest='path2nameskip', help='Skip first X folders for path2name (default: 1)',
+                        default=1, type=int ),
     parser.add_argument('-y', dest='skip_confirm', help='Skips the confirm bw installation question',
                         action="store_const", const=True, default=False)
     parser.add_argument('-v', dest='verbose', help='Verbose output', action="store_const", const=True, default=False)
@@ -34,6 +40,11 @@ def _read_password(arg, prompt):
 
 def main():
     args = _argparser().parse_args()
+
+    if (args.bw_coll and not args.bw_org):
+        sys.stderr.write(f'ERROR: -bwcoll requires --bworg\n\n')
+        _argparser().print_help()
+        sys.exit(2)
 
     # logging
     if args.verbose:
@@ -65,7 +76,12 @@ def main():
         keepass_file_path=args.keepass_file,
         keepass_password=kp_pw,
         keepass_keyfile_path=args.kp_keyfile,
-        bitwarden_password=bw_pw)
+        bitwarden_password=bw_pw,
+        bitwarden_organization_id=args.bw_org,
+        bitwarden_coll_id=args.bw_coll,
+        path2name=args.path2name,
+        path2nameskip=args.path2nameskip,
+        )
     c.convert()
 
     print(" ")


### PR DESCRIPTION

## New Features 
* Support for importing into an organization (identified by orgId)
* Support for assigning entries into an org's collection
  * either into a fixed collection (identified by collectionId)
  * or automatically accoring the KP toplevel foldername (with autocreate if collection does not exists)
* Support for prepending the KP-folderpath as breadcrumbs to the entries name (Organizations are not supporting shared folders)
   * Support for skipping the first n folder levels, default is skip first folderlevel
   * Why: Often the KP-Folder is very imporant, for example is the name of server only at folderlevel. In Bitwarden then you have 100 entries in list showing just "root" and you don't know for which server the entry is. 

## new options
```
  -bworg BW_ORG         Bitwarden Organization Id
  -bwcoll BW_COLL       Id of Org-Collection, or 'auto' to use name from toplevel-folders
  -path2name            Prepend folderpath of entries to each name
  -path2nameskip PATH2NAMESKIP
```