### PR TITLE
Nested collections support

### DIFF
--- a/kp2bw/cli.py
+++ b/kp2bw/cli.py
@@ -21,6 +21,8 @@ def _argparser():
     parser.add_argument('-bwpw', dest='bw_pw', help='Bitwarden password', default=None)
     parser.add_argument('-bworg', dest='bw_org', help='Bitwarden Organization Id', default=None)
     parser.add_argument('-bwcoll', dest='bw_coll', help='Id of Org-Collection, or \'auto\' to use name from toplevel-folders', default=None)
+    parser.add_argument('-nestcoll', dest='nestcoll', help='Creates nested collections coresponding to Keepass subfolders',
+                        action="store_const", const=True, default=False)
     parser.add_argument('-path2name', dest='path2name', help='Prepend folderpath of entries to each name',
                         action="store_const", const=True, default=True),
     parser.add_argument('-path2nameskip', dest='path2nameskip', help='Skip first X folders for path2name (default: 1)',
@@ -79,6 +81,7 @@ def main():
         bitwarden_password=bw_pw,
         bitwarden_organization_id=args.bw_org,
         bitwarden_coll_id=args.bw_coll,
+        nestcoll=args.nestcoll,
         path2name=args.path2name,
         path2nameskip=args.path2nameskip,
         )


### PR DESCRIPTION
I have added support for nesting collections when importing a keepass file with multiple nested folders as mentioned in #42 

If the -nestcoll switch is enabled, if required, it creates subcollections under the given parent collection from -bwcoll, also I have turned off folder creation for this option, as it does not seem pertinent to create folders when you are already creating subcollections

I am open to any suggestions as I am not a native python programmer, also the code could use some optimization as far as api calls are concerened