### PR TITLE
feat: added bitwarden session token as login option

### DIFF
--- a/kp2bw/bitwardenclient.py
+++ b/kp2bw/bitwardenclient.py
@@ -11,7 +11,7 @@ from subprocess import STDOUT, CalledProcessError, check_output
 class BitwardenClient():
     TEMPORARY_ATTACHMENT_FOLDER = "attachment-temp"
 
-    def __init__(self, password, orgId):
+    def __init__(self, password, orgId, session=None):
         # check for bw cli installation
         if not "bitwarden" in self._exec("bw"):
             raise Exception("Bitwarden Cli not installed! See https://help.bitwarden.com/article/cli/#download--install for help")
@@ -20,9 +20,13 @@ class BitwardenClient():
         self._orgId = orgId
 
         # login
-        self._key = self._exec(f"bw unlock \"{password}\" --raw")
-        if "error" in self._key:
-            raise Exception("Could not unlock the Bitwarden db. Is the Master Password correct and are bw cli tools set up correctly?")
+        if session:
+            logging.info("Using existing Bitwarden session")
+            self._key = session
+        else:
+            self._key = self._exec(f"bw unlock \"{password}\" --raw")
+            if "error" in self._key:
+                raise Exception("Could not unlock the Bitwarden db. Is the Master Password correct and are bw cli tools set up correctly?")
 
         # make sure data is up to date
         if not "Syncing complete." in self._exec_with_session("bw sync"):

--- a/kp2bw/cli.py
+++ b/kp2bw/cli.py
@@ -20,6 +20,7 @@ def _argparser():
     parser.add_argument('-kpkf', dest='kp_keyfile', help='KeePass db key file', default=None)
     parser.add_argument('-bwpw', dest='bw_pw', help='Bitwarden password', default=None)
     parser.add_argument('-bworg', dest='bw_org', help='Bitwarden Organization Id', default=None)
+    parser.add_argument('-bwsession', dest='bw_session', help='Bitwarden session token (aquire with bw unlock)', default=None)
     parser.add_argument('-import_tags', dest='import_tags', help='Only import tagged items', nargs='+',default=None)
     parser.add_argument('-bwcoll', dest='bw_coll', help='Id of Org-Collection, or \'auto\' to use name from toplevel-folders', default=None)
     parser.add_argument('-path2name', dest='path2name', help='Prepend folderpath of entries to each name',
@@ -70,7 +71,7 @@ def main():
 
     # stdin password
     kp_pw = _read_password(args.kp_pw, "Please enter your KeePass 2.x db password: ")
-    bw_pw = _read_password(args.bw_pw, "Please enter your Bitwarden password: ")
+    bw_pw = _read_password((args.bw_pw or args.bw_session), "Please enter your Bitwarden password: ")
 
     # call converter
     c = Converter(
@@ -78,6 +79,7 @@ def main():
         keepass_password=kp_pw,
         keepass_keyfile_path=args.kp_keyfile,
         bitwarden_password=bw_pw,
+        bitwarden_session=args.bw_session,
         bitwarden_organization_id=args.bw_org,
         bitwarden_coll_id=args.bw_coll,
         path2name=args.path2name,

--- a/kp2bw/convert.py
+++ b/kp2bw/convert.py
@@ -11,12 +11,13 @@ KP_REF_IDENTIFIER = "{REF:"
 MAX_BW_ITEM_LENGTH = 10 * 1000
 
 class Converter():
-    def __init__(self, keepass_file_path, keepass_password, keepass_keyfile_path, bitwarden_password,
+    def __init__(self, keepass_file_path, keepass_password, keepass_keyfile_path, bitwarden_password, bitwarden_session,
             bitwarden_organization_id, bitwarden_coll_id, path2name, path2nameskip, import_tags):
         self._keepass_file_path = keepass_file_path
         self._keepass_password = keepass_password
         self._keepass_keyfile_path = keepass_keyfile_path
         self._bitwarden_password = bitwarden_password
+        self._bitwarden_session = bitwarden_session
         self._bitwarden_organization_id = bitwarden_organization_id
         self._bitwarden_coll_id = bitwarden_coll_id
         self._path2name = path2name
@@ -239,7 +240,8 @@ class Converter():
 
         logging.info(f"Connecting and reading existing folders and entries")
 
-        bw = BitwardenClient(self._bitwarden_password, self._bitwarden_organization_id)
+        bw = BitwardenClient(self._bitwarden_password, self._bitwarden_organization_id, self._bitwarden_session)
+
 
         #if self._bitwarden_coll_id == 'auto':
             # lookup collections


### PR DESCRIPTION
This marks my debut with Python and my initial foray into contributing, so I welcome any guidance for future enhancements. I'm certain there's room for improvement.

I encountered an issue on both my Debian 12 and Windows 11 machines, both running Python 3.12 along with the latest Bitwarden CLI version (2024.2.0). Every time the Bitwarden CLI runs, it attempts to execute with the following output:

```
--session
mac failed.
<session token>
mac failed.
```

According to the Bitwarden forum (https://community.bitwarden.com/t/what-does-mac-failed-mean-exactly/29208), this error message has a somewhat complex underlying cause.

To address this, I attempted to use the session token directly which works perfectly fine for me.

However, it's worth noting that utilizing the session token directly from the command line may raise security concerns for some users.

Additionally, it might be beneficial to implement a safeguard preventing users from providing both bwpassword and bwsession simultaneously to mitigate any potential security risks.

Moreover, this solution could prove useful for anyone aiming to establish an automated sync setup.