### PR TITLE
fix: handle lowercase reference string

### DIFF
--- a/kp2bw/convert.py
+++ b/kp2bw/convert.py
@@ -131,7 +131,7 @@ class Converter():
         if lookup_mode == "I":
             # KP_ID lookup
             try:
-                return self._entries[ref_compare_string]
+                return self._entries[ref_compare_string.upper()]
             except Exception as e:
                 logging.warning(f"!! - Could not resolve REF to {ref_compare_string} !!")
                 raise e


### PR DESCRIPTION
In some cases, references like `{REF:P@I:7fdc71a6b2664d7590a6ea99a783bb2d}` appear.
The keys added to `self._entries` are converted to uppercase.
Converting `ref_compare_string` to uppercase resolves this issue.