### PR TITLE
BUG: bw password invalid escaping

### DIFF
--- a/kp2bw/bitwardenclient.py
+++ b/kp2bw/bitwardenclient.py
@@ -20,8 +20,8 @@ class BitwardenClient():
         self._orgId = orgId
 
         # login
-        self._key = self._exec(f"bw unlock \"{password}\" --raw")
-        if "error" in self._key:
+        self._key = self._exec("bw unlock '" + password.replace("'", "'\"'\"'") + "' --raw")
+        if "error" in self._key or "Invalid master password" in self._key:
             raise Exception("Could not unlock the Bitwarden db. Is the Master Password correct and are bw cli tools set up correctly?")
 
         # make sure data is up to date


### PR DESCRIPTION
## Problem
If password contains some special characters (e.g. `"`, `$` etc.) the program fails with JSON parse error

## Solution
1. Fix escaping password, e.g. password `asd'fgh"jkl$zxc` will be substituted as `bw unlock 'asd'"'"'fgh"jkl$zxc' --raw `
2. Fix invalid password error processing (bw returns `Invalid master password.` without word `error`)